### PR TITLE
Set a default value for DEST_DIR only if it is undefined

### DIFF
--- a/Install
+++ b/Install
@@ -2,13 +2,14 @@
   # Copying files
 
 ROOT_UID=0
-DEST_DIR=
 
 # Destination directory
-if [ "$UID" -eq "$ROOT_UID" ]; then
-  DEST_DIR="/usr/share/themes"
-else
-  DEST_DIR="$HOME/.themes"
+if [ -z "$DEST_DIR" ]; then
+  if [ "$UID" -eq "$ROOT_UID" ]; then
+    DEST_DIR="/usr/share/themes"
+  else
+    DEST_DIR="$HOME/.themes"
+  fi
 fi
 
 repodir=$(cd $(dirname $0) && pwd)


### PR DESCRIPTION
With that one can install to a different location than the default one. This makes it easy to package the theme for distributions.